### PR TITLE
Azure CI: Add missing deps for building harfbuzz

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -9,12 +9,14 @@ jobs:
   pool:
     vmImage: 'Ubuntu 16.04'
   steps:
+  - script: sudo apt-get install -y libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libegl1-mesa-dev mesa-utils mesa-utils-extra ragel
   - template: esy-build-steps.yml
 
 - job: MacOS
   pool:
     vmImage: 'macOS 10.13'
   steps:
+  - script: brew install libpng
   - template: esy-build-steps.yml
 
 - job: Windows
@@ -22,19 +24,3 @@ jobs:
     vmImage: 'vs2017-win2016'
   steps:
   - template: esy-build-steps.yml
-
-- job: Release
-  displayName: Release
-  dependsOn:
-      - Linux
-      - MacOS
-      - Windows
-  condition: succeeded()
-  pool:
-     vmImage: ubuntu-16.04
-  steps:
-    - task: PublishBuildArtifacts@1
-      displayName: 'Release Package'
-      inputs:
-          PathtoPublish: '.'
-          ArtifictName: npm-package

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -20,6 +20,7 @@ jobs:
   - template: esy-build-steps.yml
 
 - job: Windows
+  timeoutInMinutes: 120
   pool:
     vmImage: 'vs2017-win2016'
   steps:

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -4,7 +4,7 @@ steps:
   - task: NodeTool@0
     inputs:
       versionSpec: '8.9'
-  - script: npm install -g esy@0.4.2
+  - script: npm install -g esy@0.3.4
   - script: esy install
   - script: esy build
 # Might want to add running tests here - that step will be dependent on your project!

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "esy-freetype2": "^2.9.1001",
     "esy-harfbuzz": "^1.9.1"
   },
+  "resolutions": {
+    "@opam/cmdliner": "1.0.2"
+  },
   "devDependencies": {
     "ocaml": "~4.6.0"
   }


### PR DESCRIPTION
This should address the `-lpng` failure on OSX and the `ragel` failure on Linux.